### PR TITLE
Refactor Supabase initialization for runtime safety

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Node.js 18 runtime as the base image
-FROM node:18-alpine AS base
+# Use the official Node.js 20 runtime as the base image
+FROM node:20-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -1,10 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 import bcrypt from "bcryptjs"
 
 // PUT - Atualizar usuário (apenas para admins)
 export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseClient()
     const sessionToken =
       request.headers.get("authorization")?.replace("Bearer ", "") || request.cookies.get("sessionToken")?.value
 
@@ -87,6 +88,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 // DELETE - Excluir usuário (apenas para admins)
 export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseClient()
     const sessionToken =
       request.headers.get("authorization")?.replace("Bearer ", "") || request.cookies.get("sessionToken")?.value
 

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,10 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 import bcrypt from "bcryptjs"
 
 // GET - Listar usuários (apenas para admins)
 export async function GET(request: NextRequest) {
   try {
+    const supabase = getSupabaseClient()
     const sessionToken =
       request.headers.get("authorization")?.replace("Bearer ", "") || request.cookies.get("sessionToken")?.value
 
@@ -55,6 +56,7 @@ export async function GET(request: NextRequest) {
 // POST - Criar usuário (apenas para admins)
 export async function POST(request: NextRequest) {
   try {
+    const supabase = getSupabaseClient()
     const sessionToken =
       request.headers.get("authorization")?.replace("Bearer ", "") || request.cookies.get("sessionToken")?.value
 

--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -1,9 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 import bcrypt from "bcryptjs"
 
 export async function POST(request: NextRequest) {
   try {
+    const supabase = getSupabaseClient()
     const { currentPassword, newPassword } = await request.json()
 
     if (!currentPassword || !newPassword) {

--- a/app/api/debug/surveys/route.ts
+++ b/app/api/debug/surveys/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 
 export async function GET() {
   try {
+    const supabase = getSupabaseClient()
     console.log("=== DEBUG: VERIFICANDO SURVEYS NO BANCO ===")
 
     // Verificar se a tabela surveys existe e buscar dados

--- a/app/api/embed/[id]/route.tsx
+++ b/app/api/embed/[id]/route.tsx
@@ -1,8 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseClient()
     const surveyId = params.id
     const url = new URL(request.url)
     const isPreview = url.searchParams.get("preview") === "true"

--- a/app/api/feedbacks/route.ts
+++ b/app/api/feedbacks/route.ts
@@ -1,8 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 
 export async function GET() {
   try {
+    const supabase = getSupabaseClient()
     const { data: feedbacks, error } = await supabase
       .from("feedbacks")
       .select("*")
@@ -20,6 +21,7 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
+    const supabase = getSupabaseClient()
     const feedbackData = await request.json()
 
     const { data: feedback, error } = await supabase.from("feedbacks").insert(feedbackData).select().single()

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,8 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseClient()
     const { data: project, error } = await supabase
       .from("projects")
       .select(`
@@ -47,6 +48,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 
 export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseClient()
     const body = await request.json()
     const { name, description, base_domain } = body
 
@@ -115,6 +117,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
 export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseClient()
     const { data: existingProject, error: checkError } = await supabase
       .from("projects")
       .select("id")

--- a/app/api/projects/[id]/stats/route.ts
+++ b/app/api/projects/[id]/stats/route.ts
@@ -1,10 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
-
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+import { getSupabaseServiceRoleClient } from "@/lib/supabaseClient"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseServiceRoleClient()
     console.log("=== API STATS ===")
     console.log("Project ID:", params.id)
 

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,8 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 
 export async function GET(request: NextRequest) {
   try {
+    const supabase = getSupabaseClient()
     const { searchParams } = new URL(request.url)
     const search = searchParams.get("search") || ""
     const sortBy = searchParams.get("sortBy") || "newest"
@@ -75,6 +76,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
+    const supabase = getSupabaseClient()
     const body = await request.json()
     const { name, description, base_domain, created_by } = body
 

--- a/app/api/setup-db/route.ts
+++ b/app/api/setup-db/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 
 export async function POST() {
   try {
+    const supabase = getSupabaseClient()
     console.log("=== CONFIGURANDO BANCO DE DADOS ===")
 
     // Verificar se a função update_updated_at_column existe

--- a/app/api/setup-projects/route.ts
+++ b/app/api/setup-projects/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
-
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+import { getSupabaseServiceRoleClient } from "@/lib/supabaseClient"
 
 const CREATE_PROJECTS_TABLE_SQL = `-- Execute este SQL no Supabase SQL Editor:
 
@@ -59,6 +57,7 @@ WHERE NOT EXISTS (SELECT 1 FROM projects LIMIT 1);`
 
 export async function POST() {
   try {
+    const supabase = getSupabaseServiceRoleClient()
     // Verificar se a tabela projects já existe
     const { data: existingProjects, error: checkError } = await supabase.from("projects").select("id").limit(1)
 

--- a/app/api/surveys/[id]/dashboard/route.ts
+++ b/app/api/surveys/[id]/dashboard/route.ts
@@ -1,8 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseClient()
     const { searchParams } = new URL(request.url)
     const startDate = searchParams.get("startDate")
     const endDate = searchParams.get("endDate")

--- a/app/api/surveys/[id]/elements/route.ts
+++ b/app/api/surveys/[id]/elements/route.ts
@@ -1,11 +1,10 @@
-import { createClient } from "@supabase/supabase-js"
 import { type NextRequest, NextResponse } from "next/server"
-
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+import { getSupabaseServiceRoleClient } from "@/lib/supabaseClient"
 
 // GET - Buscar elementos ativos da survey
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseServiceRoleClient()
     const { data: elements, error } = await supabase
       .from("survey_elements")
       .select("*")
@@ -28,6 +27,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 // DELETE - Soft delete de elemento (NUNCA hard delete)
 export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseServiceRoleClient()
     const { elementId } = await request.json()
 
     const { error } = await supabase

--- a/app/api/surveys/[id]/exposures/route.ts
+++ b/app/api/surveys/[id]/exposures/route.ts
@@ -1,8 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
 import { getDeviceType } from "@/lib/device-parser"
-
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+import { getSupabaseServiceRoleClient } from "@/lib/supabaseClient"
 
 export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
   const headers = {
@@ -12,6 +10,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
   }
 
   try {
+    const supabase = getSupabaseServiceRoleClient()
     const surveyId = params.id
     const body = await request.json()
 

--- a/app/api/surveys/[id]/hits/route.ts
+++ b/app/api/surveys/[id]/hits/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 
 export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
   const headers = {
@@ -9,6 +9,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
   }
 
   try {
+    const supabase = getSupabaseClient()
     const surveyId = params.id
     const body = await request.json()
 

--- a/app/api/surveys/[id]/metrics/route.ts
+++ b/app/api/surveys/[id]/metrics/route.ts
@@ -1,10 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
-
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+import { getSupabaseServiceRoleClient } from "@/lib/supabaseClient"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseServiceRoleClient()
     const surveyId = params.id
     const { searchParams } = new URL(request.url)
 

--- a/app/api/surveys/[id]/responses/[responseId]/route.ts
+++ b/app/api/surveys/[id]/responses/[responseId]/route.ts
@@ -1,9 +1,8 @@
-import { createClient } from "@supabase/supabase-js"
-
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+import { getSupabaseServiceRoleClient } from "@/lib/supabaseClient"
 
 export async function PATCH(request: Request, { params }: { params: { id: string; responseId: string } }) {
   try {
+    const supabase = getSupabaseServiceRoleClient()
     const { is_test } = await request.json()
 
     console.log("[v0] PATCH request received:", {

--- a/app/api/surveys/[id]/responses/route.ts
+++ b/app/api/surveys/[id]/responses/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 import { parseDeviceFromUserAgent } from "@/lib/device-parser"
 
 function corsHeaders() {
@@ -19,6 +19,7 @@ export async function OPTIONS(request: NextRequest) {
 
 export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseClient()
     console.log("[v0] === SURVEY RESPONSES API DEBUG ===")
     console.log("[v0] Survey ID:", params.id)
 

--- a/app/api/surveys/[id]/route.ts
+++ b/app/api/surveys/[id]/route.ts
@@ -1,9 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 import type { Survey } from "@/types/survey"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseClient()
     // Buscar survey principal
     const { data: survey, error: surveyError } = await supabase.from("surveys").select("*").eq("id", params.id).single()
 
@@ -82,6 +83,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 
 export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseClient()
     const surveyData: Survey = await request.json()
 
     const { data: existingSurvey, error: checkError } = await supabase
@@ -164,6 +166,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
 export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseClient()
     const { error } = await supabase.from("surveys").delete().eq("id", params.id)
 
     if (error) {

--- a/app/api/surveys/[id]/toggle-status/route.ts
+++ b/app/api/surveys/[id]/toggle-status/route.ts
@@ -1,10 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
-
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+import { getSupabaseServiceRoleClient } from "@/lib/supabaseClient"
 
 export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    const supabase = getSupabaseServiceRoleClient()
     const { is_active } = await request.json()
     const surveyId = params.id
 

--- a/app/api/surveys/activity/route.ts
+++ b/app/api/surveys/activity/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 
 export async function GET() {
   try {
+    const supabase = getSupabaseClient()
     // Buscar respostas das últimas 24 horas
     const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
 

--- a/app/api/surveys/route.ts
+++ b/app/api/surveys/route.ts
@@ -1,9 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 import type { Survey } from "@/types/survey"
 
 export async function GET(request: NextRequest) {
   try {
+    const supabase = getSupabaseClient()
     console.log("=== API GET SURVEYS ===")
 
     const { searchParams } = new URL(request.url)
@@ -178,6 +179,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
+    const supabase = getSupabaseClient()
     const surveyData: Survey = await request.json()
 
     console.log("=== API POST SURVEY ===")

--- a/app/api/test-db/route.ts
+++ b/app/api/test-db/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
+import { getSupabaseClient } from "@/lib/supabaseClient"
 
 export async function GET() {
   try {
+    const supabase = getSupabaseClient()
     console.log("=== TESTE DE CONFIGURAÇÃO DO BANCO ===")
 
     // Verificar variáveis de ambiente

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,12 +1,3 @@
-import { createClient } from "@supabase/supabase-js"
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
-
-export { createClient }
-
 // Tipos para o banco de dados
 export interface User {
   id: string

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,34 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+
+let cachedBrowserClient: SupabaseClient | null = null
+let cachedServiceRoleClient: SupabaseClient | null = null
+
+export function getSupabaseClient(): SupabaseClient {
+  if (!cachedBrowserClient) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+    if (!url || !anonKey) {
+      throw new Error("Missing Supabase environment variables")
+    }
+
+    cachedBrowserClient = createClient(url, anonKey)
+  }
+
+  return cachedBrowserClient
+}
+
+export function getSupabaseServiceRoleClient(): SupabaseClient {
+  if (!cachedServiceRoleClient) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+    if (!url || !serviceRoleKey) {
+      throw new Error("Missing Supabase service role environment variables")
+    }
+
+    cachedServiceRoleClient = createClient(url, serviceRoleKey)
+  }
+
+  return cachedServiceRoleClient
+}


### PR DESCRIPTION
## Summary
- add a reusable Supabase client helper that defers environment variable access to runtime
- update API routes to request Supabase clients within handlers, covering both anon and service-role use cases
- bump the Docker image to Node.js 20-alpine to match supported @supabase/supabase-js versions

## Testing
- pnpm lint *(fails: existing hook dependency and unescaped entity lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68dde22d8dc483319c25adcc0590a04f